### PR TITLE
fix: Export types and rename useSafe return type

### DIFF
--- a/src/hooks/useSafe.ts
+++ b/src/hooks/useSafe.ts
@@ -13,7 +13,7 @@ import {
 import { MissingSafeProviderError } from '@/errors/MissingSafeProviderError.js'
 import { SafeContext } from '@/SafeContext.js'
 
-export type UseReturnType = UseConnectSignerReturnType & {
+export type UseSafeReturnType = UseConnectSignerReturnType & {
   isInitialized: boolean
   getBalance: typeof useBalance
   getChain: typeof useChain
@@ -28,7 +28,7 @@ export type UseReturnType = UseConnectSignerReturnType & {
  * Top-level hook to get Safe-related information.
  * @returns Object wrapping the Safe hooks.
  */
-export function useSafe(): UseReturnType {
+export function useSafe(): UseSafeReturnType {
   const { isInitialized, config } = useContext(SafeContext)
 
   if (!config) {

--- a/src/hooks/useSendTransaction.ts
+++ b/src/hooks/useSendTransaction.ts
@@ -7,7 +7,7 @@ import { useWaitForTransaction } from '@/hooks/useWaitForTransaction.js'
 import { MutationKey, QueryKey } from '@/constants.js'
 import { invalidateQueries } from '@/queryClient.js'
 
-type SendTransactionVariables = { transactions: (TransactionBase | SafeTransaction)[] }
+export type SendTransactionVariables = { transactions: (TransactionBase | SafeTransaction)[] }
 
 export type UseSendTransactionParams = ConfigParam<SafeConfigWithSigner>
 export type UseSendTransactionReturnType = Omit<

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-export {
-  useConfirmTransaction,
-  useSafe,
-  useSendTransaction,
-  useUpdateOwners,
-  useUpdateThreshold
-} from '@/hooks/index.js'
+export * from '@/hooks/useSafe.js'
+export * from '@/hooks/useConfirmTransaction.js'
+export * from '@/hooks/useSendTransaction.js'
+export * from '@/hooks/useUpdateOwners/index.js'
+export * from '@/hooks/useUpdateThreshold.js'
+
 export * from '@/types/index.js'
+
 export { SafeProvider } from './SafeProvider.js'
 export { SafeContext } from './SafeContext.js'
 export { createConfig } from './createConfig.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export * from '@/hooks/useUpdateThreshold.js'
 
 export * from '@/types/index.js'
 
-export { SafeProvider } from './SafeProvider.js'
-export { SafeContext } from './SafeContext.js'
+export * from './SafeProvider.js'
+export { SafeContext, SafeContextType } from './SafeContext.js'
 export { createConfig } from './createConfig.js'


### PR DESCRIPTION
- Add missing types for hooks, SafeProvider and SafeContext to exports
- Rename `useSafe` hook's return type to `UseSafeReturnType`