### PR TITLE
Update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@safe-global/sdk-starter-kit": "2.0.0-alpha.2",
+    "@safe-global/sdk-starter-kit": "2.0.0-alpha.3",
     "viem": "^2.18.6",
     "wagmi": "^2.12.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-react-hooks",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A collection of React Hooks that facilitates the interaction of React apps with Safe Smart Accounts",
   "keywords": [
     "Ethereum",
@@ -43,7 +43,7 @@
     "typescript": ">=5.0.4"
   },
   "devDependencies": {
-    "@safe-global/types-kit": "^1.0.0",
+    "@safe-global/types-kit": "2.0.0-alpha.2",
     "@tanstack/react-query": ">=5.45.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.8",
@@ -67,7 +67,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@safe-global/sdk-starter-kit": "^1.1.0",
+    "@safe-global/sdk-starter-kit": "2.0.0-alpha.2",
     "viem": "^2.18.6",
     "wagmi": "^2.12.2"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "typescript": ">=5.0.4"
   },
   "devDependencies": {
-    "@safe-global/types-kit": "2.0.0-alpha.2",
     "@tanstack/react-query": ">=5.45.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.8",
@@ -67,7 +66,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@safe-global/sdk-starter-kit": "2.0.0-alpha.3",
+    "@safe-global/sdk-starter-kit": "^2.0.1",
+    "@safe-global/types-kit": "^2.0.1",
     "viem": "^2.18.6",
     "wagmi": "^2.12.2"
   },

--- a/src/createClient.test.ts
+++ b/src/createClient.test.ts
@@ -3,12 +3,20 @@ import { createPublicClient, createSignerClient } from '@/createClient.js'
 import { configExistingSafe, configPredictedSafe } from '@test/config.js'
 import { signerPrivateKeys } from '@test/fixtures/index.js'
 
+jest.mock('@safe-global/sdk-starter-kit', () => ({
+  createSafeClient: jest.fn()
+}))
+
 describe('createClient', () => {
   const safeClientMock = { safe: 'client' } as unknown as sdkStarterKit.SafeClient
 
   const createSafeClientSpy = jest
     .spyOn(sdkStarterKit, 'createSafeClient')
     .mockResolvedValue(safeClientMock)
+
+  beforeEach(() => {
+    ;(sdkStarterKit.createSafeClient as jest.Mock).mockResolvedValue(safeClientMock)
+  })
 
   afterEach(() => {
     jest.clearAllMocks()

--- a/src/hooks/useConfirmSafeOperation.ts
+++ b/src/hooks/useConfirmSafeOperation.ts
@@ -52,7 +52,11 @@ export function useConfirmSafeOperation(
       })
 
       if (result.safeOperations?.userOperationHash) {
-        invalidateQueries([QueryKey.SafeOperations, QueryKey.SafeInfo])
+        invalidateQueries([
+          QueryKey.SafeOperations,
+          QueryKey.SafeInfo,
+          QueryKey.PendingSafeOperations
+        ])
       } else if (result.safeOperations?.safeOperationHash) {
         invalidateQueries([QueryKey.PendingSafeOperations])
       }

--- a/src/hooks/useSafeOperations.ts
+++ b/src/hooks/useSafeOperations.ts
@@ -29,8 +29,7 @@ export function useSafeOperations(
       throw new Error('SafeClient not initialized')
     }
 
-    const response = await safeClient.apiKit.getSafeOperationsByAddress({
-      safeAddress: address,
+    const response = await safeClient.apiKit.getSafeOperationsByAddress(address, {
       limit: params.limit,
       offset: params.offset,
       ordering: params.ordering

--- a/src/hooks/useSendSafeOperation.ts
+++ b/src/hooks/useSendSafeOperation.ts
@@ -48,7 +48,11 @@ export function useSendSafeOperation(
       })
 
       if (result.safeOperations?.userOperationHash) {
-        invalidateQueries([QueryKey.SafeOperations, QueryKey.SafeInfo])
+        invalidateQueries([
+          QueryKey.SafeOperations,
+          QueryKey.SafeInfo,
+          QueryKey.PendingSafeOperations
+        ])
       } else if (result.safeOperations?.safeOperationHash) {
         invalidateQueries([QueryKey.PendingSafeOperations])
       }

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -63,7 +63,15 @@ export const safeMultisigTransaction: SafeMultisigTransaction = {
   isExecuted: false,
   origin: '{}',
   confirmationsRequired: 2,
-  trusted: true
+  trusted: true,
+  proposedByDelegate: null,
+  isSuccessful: null,
+  ethGasPrice: null,
+  maxFeePerGas: null,
+  maxPriorityFeePerGas: null,
+  gasUsed: null,
+  fee: null,
+  signatures: null
 }
 
 export const safeModuleTransaction: SafeModuleTransaction = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,24 +1086,24 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@safe-global/api-kit@^3.0.0-alpha.2":
-  version "3.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/api-kit/-/api-kit-3.0.0-alpha.2.tgz#fd94ad434fa6c31d85e168f9aa554ce9b13b3da1"
-  integrity sha512-c37y14bfNNJK9SSA3nLTpXOt1pShGWQBM4qOAxPnT5v6A00qQWjNKv61b0TS5Fp4VH2GT6LPS/QpL9AV7MMW8Q==
+"@safe-global/api-kit@^3.0.0-alpha.3":
+  version "3.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@safe-global/api-kit/-/api-kit-3.0.0-alpha.3.tgz#f4819af24a492efeb06487571269b3243630d01d"
+  integrity sha512-GJYwxba9ebKUFP87SUto2q7tdX8+fDwkm5osPljSE2O8knuC26sstvdtvfXL8yMTOM8NT+r/UYjHyBZkT1SnMA==
   dependencies:
-    "@safe-global/protocol-kit" "^6.0.0-alpha.2"
-    "@safe-global/types-kit" "^2.0.0-alpha.2"
+    "@safe-global/protocol-kit" "^6.0.0-alpha.3"
+    "@safe-global/types-kit" "^2.0.0-alpha.3"
     node-fetch "^2.7.0"
     viem "^2.21.8"
 
-"@safe-global/protocol-kit@^6.0.0-alpha.2":
-  version "6.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/protocol-kit/-/protocol-kit-6.0.0-alpha.2.tgz#a1eae60815dcde3fbf84adb913c08d28d46a1772"
-  integrity sha512-Mj9CkcicwauKst9/XKKyMxzyDpNtOR1CeD3EsxtAg+QiVF6CgwN+GHsgnTfUPHc0RE6MEVFYn7bSnO8F/dyTDw==
+"@safe-global/protocol-kit@^6.0.0-alpha.3":
+  version "6.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@safe-global/protocol-kit/-/protocol-kit-6.0.0-alpha.3.tgz#f5914570a935426b758216e40f2c074d878df374"
+  integrity sha512-th45iACMXBbI7GS8vTnRqKRkjJJoJXmcwfgYNk/DSyPPwEPwp21EKUoydnBksSKHHxIq3xoCDxmjuTP+Zz0EBA==
   dependencies:
     "@safe-global/safe-deployments" "^1.37.28"
     "@safe-global/safe-modules-deployments" "^2.2.5"
-    "@safe-global/types-kit" "^2.0.0-alpha.2"
+    "@safe-global/types-kit" "^2.0.0-alpha.3"
     abitype "^1.0.2"
     semver "^7.6.3"
     viem "^2.21.8"
@@ -1111,15 +1111,15 @@
     "@noble/curves" "^1.6.0"
     "@peculiar/asn1-schema" "^2.3.13"
 
-"@safe-global/relay-kit@^4.0.0-alpha.2":
-  version "4.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/relay-kit/-/relay-kit-4.0.0-alpha.2.tgz#1dec67c27942b3cd6370fae0bcdb9002b54efce9"
-  integrity sha512-/Zoc9R02oKHa2gSvhkvWV0RHRzs66JlZwtvGYvl9ibl4ssxTkcKfqLSMZkFqeZ83z2A90Z66FWI/jCwhExCeYA==
+"@safe-global/relay-kit@^4.0.0-alpha.3":
+  version "4.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@safe-global/relay-kit/-/relay-kit-4.0.0-alpha.3.tgz#229fb748d87397a2a704ba36f9b66e12210783c2"
+  integrity sha512-1JvrYXN4QcXmMQVoHXP4qrsYbJXiPHrnxHrphZbXi9m+FIh5EnWiypP9nNsHZormQs+n9eJrLWa80m8bECzvLA==
   dependencies:
     "@gelatonetwork/relay-sdk" "^5.5.0"
-    "@safe-global/protocol-kit" "^6.0.0-alpha.2"
+    "@safe-global/protocol-kit" "^6.0.0-alpha.3"
     "@safe-global/safe-modules-deployments" "^2.2.5"
-    "@safe-global/types-kit" "^2.0.0-alpha.2"
+    "@safe-global/types-kit" "^2.0.0-alpha.3"
     semver "^7.6.3"
     viem "^2.21.8"
 
@@ -1156,21 +1156,28 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.7.tgz#8d9cabea778767776de2dc62258dcc458f2f2c14"
   integrity sha512-xlnAW7d0394EwlRgWJ+nuQNQmGkL0qBE54pN+1IBbUEFvWW8q0SbhDsTmlGgeDM+9F8q2KM06Ip1JMmddppA/Q==
 
-"@safe-global/sdk-starter-kit@2.0.0-alpha.2":
-  version "2.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/sdk-starter-kit/-/sdk-starter-kit-2.0.0-alpha.2.tgz#2cbdbaac94954191ef13dc51cf5435079c80ac22"
-  integrity sha512-EJM7UYSenw2j+wRDeV2HXIOw8ZL24sJJLO16GblyNGqUFX4XOwLII1ReATcW/yTMPFH2A9I3ZzrKqwj19ucM5A==
+"@safe-global/sdk-starter-kit@2.0.0-alpha.3":
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@safe-global/sdk-starter-kit/-/sdk-starter-kit-2.0.0-alpha.3.tgz#9b6a8484fa036b0d7eeb7a4530cc51d358c65405"
+  integrity sha512-T7gbaHf07otUM9Y8OgC+Cc1AdFYx9keyOiFk/Vc5/I9sfbeTvjZM1JE1rnSf33EiSsTkCEDQY/2oCxnR0zgX1g==
   dependencies:
-    "@safe-global/api-kit" "^3.0.0-alpha.2"
-    "@safe-global/protocol-kit" "^6.0.0-alpha.2"
-    "@safe-global/relay-kit" "^4.0.0-alpha.2"
-    "@safe-global/types-kit" "^2.0.0-alpha.2"
+    "@safe-global/api-kit" "^3.0.0-alpha.3"
+    "@safe-global/protocol-kit" "^6.0.0-alpha.3"
+    "@safe-global/relay-kit" "^4.0.0-alpha.3"
+    "@safe-global/types-kit" "^2.0.0-alpha.3"
     viem "^2.21.8"
 
-"@safe-global/types-kit@2.0.0-alpha.2", "@safe-global/types-kit@^2.0.0-alpha.2":
+"@safe-global/types-kit@2.0.0-alpha.2":
   version "2.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-2.0.0-alpha.2.tgz#4b2792258bd77953ec6171b6c135fe9821febb57"
   integrity sha512-M6I7xMmuB8ZnMTBBny3T+8Rbzsawr6guLL1khFYndfnZ+LG845Oiw+cxd+e7+rZg7DZjTtJ+P5YdFIj1iPpBuQ==
+  dependencies:
+    abitype "^1.0.2"
+
+"@safe-global/types-kit@^2.0.0-alpha.3":
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-2.0.0-alpha.3.tgz#1600e28a8485c44aadd0293506774d0bd8dce7ca"
+  integrity sha512-IkR6dtft5zlEM/Wur9yeIMvvd+2015aQvOUdboKitcPvcyZRw9LAKpAc5COvXF2UAbKOt9tZMwY1ImtU9xIqhg==
   dependencies:
     abitype "^1.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,15 +375,15 @@
     ethereum-cryptography "^2.0.0"
     micro-ftch "^0.3.1"
 
-"@gelatonetwork/relay-sdk@^5.5.0":
-  version "5.5.6"
-  resolved "https://registry.yarnpkg.com/@gelatonetwork/relay-sdk/-/relay-sdk-5.5.6.tgz#c0d249c9431f0d364a93c547ea3110b6e462cc57"
-  integrity sha512-wGUbBhz9iJUhagzW/+rik5nQ+X6YVDMQcH0PWxvSNB4Swu/EnPjqTVOJzf3CnS+pvCMNLChOEUw4caRbZXyq0w==
+"@gelatonetwork/relay-sdk@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@gelatonetwork/relay-sdk/-/relay-sdk-5.6.0.tgz#02c3114472cbe6dd310415818fb5477e444f3c4a"
+  integrity sha512-pSXE9xdPj6wmdcmoT7ETlbEjpvQvyFIZT1CoyzcUEupPplugm59ieUiX5E41oLeByQ7M1dliq2b96d/iIIA3kw==
   dependencies:
-    axios "0.27.2"
+    axios "0.29.0"
     ethers "6.7.0"
     isomorphic-ws "^5.0.0"
-    ws "^8.5.0"
+    ws "^8.18.0"
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -1086,41 +1086,41 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@safe-global/api-kit@^3.0.0-alpha.3":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/api-kit/-/api-kit-3.0.0-alpha.3.tgz#f4819af24a492efeb06487571269b3243630d01d"
-  integrity sha512-GJYwxba9ebKUFP87SUto2q7tdX8+fDwkm5osPljSE2O8knuC26sstvdtvfXL8yMTOM8NT+r/UYjHyBZkT1SnMA==
+"@safe-global/api-kit@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/api-kit/-/api-kit-3.0.1.tgz#cea6eb27b33a34568b29ac0507e62714445e35e5"
+  integrity sha512-ks7vFMU3l/xl1TWKL2c+a8l5aQRCtOtSMMpxfJIMsJvtvPSTAUx/WDFKqtVlMhVP/QrqaL7YiTw8hM2vhkTdDQ==
   dependencies:
-    "@safe-global/protocol-kit" "^6.0.0-alpha.3"
-    "@safe-global/types-kit" "^2.0.0-alpha.3"
+    "@safe-global/protocol-kit" "^6.0.1"
+    "@safe-global/types-kit" "^2.0.0"
     node-fetch "^2.7.0"
     viem "^2.21.8"
 
-"@safe-global/protocol-kit@^6.0.0-alpha.3":
-  version "6.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/protocol-kit/-/protocol-kit-6.0.0-alpha.3.tgz#f5914570a935426b758216e40f2c074d878df374"
-  integrity sha512-th45iACMXBbI7GS8vTnRqKRkjJJoJXmcwfgYNk/DSyPPwEPwp21EKUoydnBksSKHHxIq3xoCDxmjuTP+Zz0EBA==
+"@safe-global/protocol-kit@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/protocol-kit/-/protocol-kit-6.0.2.tgz#5bd43a51fbc3c6d7f8b2f90a40ecbba61b9b8f05"
+  integrity sha512-Bdj78qra3lOXe/H/6WM+w3oe149rdyVNCYRjNkFVWlqvWYYLMficE8E1x3OmNrduik2g8Ca+qZblNJ16T8pMBQ==
   dependencies:
-    "@safe-global/safe-deployments" "^1.37.28"
-    "@safe-global/safe-modules-deployments" "^2.2.5"
-    "@safe-global/types-kit" "^2.0.0-alpha.3"
+    "@safe-global/safe-deployments" "^1.37.31"
+    "@safe-global/safe-modules-deployments" "^2.2.7"
+    "@safe-global/types-kit" "^2.0.1"
     abitype "^1.0.2"
-    semver "^7.6.3"
+    semver "^7.7.1"
     viem "^2.21.8"
   optionalDependencies:
     "@noble/curves" "^1.6.0"
     "@peculiar/asn1-schema" "^2.3.13"
 
-"@safe-global/relay-kit@^4.0.0-alpha.3":
-  version "4.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/relay-kit/-/relay-kit-4.0.0-alpha.3.tgz#229fb748d87397a2a704ba36f9b66e12210783c2"
-  integrity sha512-1JvrYXN4QcXmMQVoHXP4qrsYbJXiPHrnxHrphZbXi9m+FIh5EnWiypP9nNsHZormQs+n9eJrLWa80m8bECzvLA==
+"@safe-global/relay-kit@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/relay-kit/-/relay-kit-4.0.1.tgz#569c569b42912bd916dea2714805ff8121714db9"
+  integrity sha512-pMzxBmhhwtkmHE2wJL7UBEUYd1posHIZY/PkUaLIf154FIaNHBmzpu3C31EwgmvFaiDhp+NcD3eNQVLOg501pg==
   dependencies:
-    "@gelatonetwork/relay-sdk" "^5.5.0"
-    "@safe-global/protocol-kit" "^6.0.0-alpha.3"
-    "@safe-global/safe-modules-deployments" "^2.2.5"
-    "@safe-global/types-kit" "^2.0.0-alpha.3"
-    semver "^7.6.3"
+    "@gelatonetwork/relay-sdk" "^5.6.0"
+    "@safe-global/protocol-kit" "^6.0.1"
+    "@safe-global/safe-modules-deployments" "^2.2.7"
+    "@safe-global/types-kit" "^2.0.0"
+    semver "^7.7.1"
     viem "^2.21.8"
 
 "@safe-global/safe-apps-provider@0.18.3":
@@ -1139,10 +1139,10 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^2.1.1"
 
-"@safe-global/safe-deployments@^1.37.28":
-  version "1.37.29"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.29.tgz#60534d0c9abb03bb1e31a2b4e2d448a6c4644f9f"
-  integrity sha512-z4ad9ingF2tAXYgS2KAEei/4HGxNDpAjmVRVFsJa6VHNfyTPyR7h/U973JJ6y/RTdhrxUhF7mYr/KB7LQ5PfSg==
+"@safe-global/safe-deployments@^1.37.31":
+  version "1.37.31"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.31.tgz#582120fb2468a0f3bb284f0d3c6c94bb61b151f7"
+  integrity sha512-9ab33ttfSTiWCYKwI7n7eky9bNPQD0f21cCTu/nn4+OwjZvYUrcYfmxNvjXy3JERDToHbalAZ1KHUjfA0teN4A==
   dependencies:
     semver "^7.6.2"
 
@@ -1151,33 +1151,26 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.1.tgz#4d5dac21c6e044b68b13b53468633ec771f30e3b"
   integrity sha512-YApSpx+3h6uejrJVh8PSqXRRAwmsWz8PZERObMGJNC9NPoMhZG/Rvqb2UWmVLrjFh880rqutsB+GrTmJP351PA==
 
-"@safe-global/safe-modules-deployments@^2.2.5":
+"@safe-global/safe-modules-deployments@^2.2.7":
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.7.tgz#8d9cabea778767776de2dc62258dcc458f2f2c14"
   integrity sha512-xlnAW7d0394EwlRgWJ+nuQNQmGkL0qBE54pN+1IBbUEFvWW8q0SbhDsTmlGgeDM+9F8q2KM06Ip1JMmddppA/Q==
 
-"@safe-global/sdk-starter-kit@2.0.0-alpha.3":
-  version "2.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/sdk-starter-kit/-/sdk-starter-kit-2.0.0-alpha.3.tgz#9b6a8484fa036b0d7eeb7a4530cc51d358c65405"
-  integrity sha512-T7gbaHf07otUM9Y8OgC+Cc1AdFYx9keyOiFk/Vc5/I9sfbeTvjZM1JE1rnSf33EiSsTkCEDQY/2oCxnR0zgX1g==
+"@safe-global/sdk-starter-kit@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/sdk-starter-kit/-/sdk-starter-kit-2.0.1.tgz#fb2be29754e6e68d309aebdaa1b848bacfdeaeca"
+  integrity sha512-9npK1nmkQsstmDg/LSqNcBruwKR/iI8HMfv5OUOTQAR29CwDu/sMOVnOTd0XuG8f7+IH8ZzS9M2sOIyFozkKiw==
   dependencies:
-    "@safe-global/api-kit" "^3.0.0-alpha.3"
-    "@safe-global/protocol-kit" "^6.0.0-alpha.3"
-    "@safe-global/relay-kit" "^4.0.0-alpha.3"
-    "@safe-global/types-kit" "^2.0.0-alpha.3"
+    "@safe-global/api-kit" "^3.0.1"
+    "@safe-global/protocol-kit" "^6.0.1"
+    "@safe-global/relay-kit" "^4.0.1"
+    "@safe-global/types-kit" "^2.0.0"
     viem "^2.21.8"
 
-"@safe-global/types-kit@2.0.0-alpha.2":
-  version "2.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-2.0.0-alpha.2.tgz#4b2792258bd77953ec6171b6c135fe9821febb57"
-  integrity sha512-M6I7xMmuB8ZnMTBBny3T+8Rbzsawr6guLL1khFYndfnZ+LG845Oiw+cxd+e7+rZg7DZjTtJ+P5YdFIj1iPpBuQ==
-  dependencies:
-    abitype "^1.0.2"
-
-"@safe-global/types-kit@^2.0.0-alpha.3":
-  version "2.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-2.0.0-alpha.3.tgz#1600e28a8485c44aadd0293506774d0bd8dce7ca"
-  integrity sha512-IkR6dtft5zlEM/Wur9yeIMvvd+2015aQvOUdboKitcPvcyZRw9LAKpAc5COvXF2UAbKOt9tZMwY1ImtU9xIqhg==
+"@safe-global/types-kit@^2.0.0", "@safe-global/types-kit@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-2.0.1.tgz#f2334a33fa430beceba017bd7dbb112269f61f30"
+  integrity sha512-4xKjTBlyFSIKziqvjrGMBAgs7Z2+s/5A2wjAXg2gBA1BuvV6w1THk1Y/WMZg8+6/PlRaVMVo4LoSNMRSsZZhjw==
   dependencies:
     abitype "^1.0.2"
 
@@ -2149,13 +2142,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.29.0.tgz#5eed1a0bc4c0ffe060624eb7900aff66b7881eeb"
+  integrity sha512-Kjsq1xisgO5DjjNQwZFsy0gpcU1P2j36dZeQDXVhpIU26GVgkDUnROaHLSuluhMqtDE7aKA2hbKXG5yu5DN8Tg==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.4"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -3257,7 +3251,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.14.9:
+follow-redirects@^1.15.4:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -5027,6 +5021,11 @@ proxy-compare@2.5.1:
   resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.5.1.tgz#17818e33d1653fbac8c2ec31406bce8a2966f600"
   integrity sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -5342,6 +5341,11 @@ semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semve
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
+semver@^7.7.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -6088,10 +6092,15 @@ ws@^7.5.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.11.0, ws@^8.5.0:
+ws@^8.11.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+ws@^8.18.0:
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.1.tgz#ea131d3784e1dfdff91adb0a4a116b127515e3cb"
+  integrity sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,24 +1086,24 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@safe-global/api-kit@^2.5.5":
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/@safe-global/api-kit/-/api-kit-2.5.5.tgz#585bfc0b0072f84e515191b70ccd5f570948c985"
-  integrity sha512-/0gMUW2FX3JvgMOZfZes4VQ+QJrrf2hxn62slZsbrCUDc6hukOpLM7njQWWabPFp2y+SgrcUJxawRmB6vl8MmA==
+"@safe-global/api-kit@^3.0.0-alpha.2":
+  version "3.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/api-kit/-/api-kit-3.0.0-alpha.2.tgz#fd94ad434fa6c31d85e168f9aa554ce9b13b3da1"
+  integrity sha512-c37y14bfNNJK9SSA3nLTpXOt1pShGWQBM4qOAxPnT5v6A00qQWjNKv61b0TS5Fp4VH2GT6LPS/QpL9AV7MMW8Q==
   dependencies:
-    "@safe-global/protocol-kit" "^5.1.0"
-    "@safe-global/types-kit" "^1.0.1"
+    "@safe-global/protocol-kit" "^6.0.0-alpha.2"
+    "@safe-global/types-kit" "^2.0.0-alpha.2"
     node-fetch "^2.7.0"
     viem "^2.21.8"
 
-"@safe-global/protocol-kit@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/protocol-kit/-/protocol-kit-5.1.0.tgz#53e43802eccd897c806860ae0cc8fc3f793f8d0b"
-  integrity sha512-tBLadf7yTGny9m56Fi+2aKhDo+IuxwXoBj4tt+E3kWIUbY4yB14Ed34eaVrpkMGuHzNMvH8HQlqnUqdpxgRJAQ==
+"@safe-global/protocol-kit@^6.0.0-alpha.2":
+  version "6.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/protocol-kit/-/protocol-kit-6.0.0-alpha.2.tgz#a1eae60815dcde3fbf84adb913c08d28d46a1772"
+  integrity sha512-Mj9CkcicwauKst9/XKKyMxzyDpNtOR1CeD3EsxtAg+QiVF6CgwN+GHsgnTfUPHc0RE6MEVFYn7bSnO8F/dyTDw==
   dependencies:
-    "@safe-global/safe-deployments" "^1.37.20"
-    "@safe-global/safe-modules-deployments" "^2.2.4"
-    "@safe-global/types-kit" "^1.0.1"
+    "@safe-global/safe-deployments" "^1.37.28"
+    "@safe-global/safe-modules-deployments" "^2.2.5"
+    "@safe-global/types-kit" "^2.0.0-alpha.2"
     abitype "^1.0.2"
     semver "^7.6.3"
     viem "^2.21.8"
@@ -1111,15 +1111,16 @@
     "@noble/curves" "^1.6.0"
     "@peculiar/asn1-schema" "^2.3.13"
 
-"@safe-global/relay-kit@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/relay-kit/-/relay-kit-3.3.0.tgz#e65effa6cff650931417e545a30d83f833dc4e5c"
-  integrity sha512-U65jig5Mw4Wpj6lfFIwbZF5czUnF0bXJh0bo7EHGCEl0iRln4mj976bJBcbfYs+CnWzJi9d/5LV94J2cQLCoKQ==
+"@safe-global/relay-kit@^4.0.0-alpha.2":
+  version "4.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/relay-kit/-/relay-kit-4.0.0-alpha.2.tgz#1dec67c27942b3cd6370fae0bcdb9002b54efce9"
+  integrity sha512-/Zoc9R02oKHa2gSvhkvWV0RHRzs66JlZwtvGYvl9ibl4ssxTkcKfqLSMZkFqeZ83z2A90Z66FWI/jCwhExCeYA==
   dependencies:
     "@gelatonetwork/relay-sdk" "^5.5.0"
-    "@safe-global/protocol-kit" "^5.1.0"
-    "@safe-global/safe-modules-deployments" "^2.2.4"
-    "@safe-global/types-kit" "^1.0.1"
+    "@safe-global/protocol-kit" "^6.0.0-alpha.2"
+    "@safe-global/safe-modules-deployments" "^2.2.5"
+    "@safe-global/types-kit" "^2.0.0-alpha.2"
+    semver "^7.6.3"
     viem "^2.21.8"
 
 "@safe-global/safe-apps-provider@0.18.3":
@@ -1138,10 +1139,10 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^2.1.1"
 
-"@safe-global/safe-deployments@^1.37.20":
-  version "1.37.21"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.21.tgz#9b194c08a5605bb012d0bc321a74d322d107e361"
-  integrity sha512-Q5qvcxXjAIcKOO8e3uQ/iNOSE5vRI+5jCO6JW/id5tEwMBtfyj5Ec2Vkk6nz0AM0uo2pyGROYjNTTuefoTthvQ==
+"@safe-global/safe-deployments@^1.37.28":
+  version "1.37.29"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.29.tgz#60534d0c9abb03bb1e31a2b4e2d448a6c4644f9f"
+  integrity sha512-z4ad9ingF2tAXYgS2KAEei/4HGxNDpAjmVRVFsJa6VHNfyTPyR7h/U973JJ6y/RTdhrxUhF7mYr/KB7LQ5PfSg==
   dependencies:
     semver "^7.6.2"
 
@@ -1150,33 +1151,26 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.1.tgz#4d5dac21c6e044b68b13b53468633ec771f30e3b"
   integrity sha512-YApSpx+3h6uejrJVh8PSqXRRAwmsWz8PZERObMGJNC9NPoMhZG/Rvqb2UWmVLrjFh880rqutsB+GrTmJP351PA==
 
-"@safe-global/safe-modules-deployments@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.4.tgz#6e3b22af3a4eeba8e0a8f0952e575d25c5be216e"
-  integrity sha512-m396ZrBPhZVYkapTTIuizyOOtoZsCKbicl0ztgDFfDbi7KbS6AtDP6cV89AYosQxUQS+v0q4ksQd30/j3L1BtQ==
+"@safe-global/safe-modules-deployments@^2.2.5":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.7.tgz#8d9cabea778767776de2dc62258dcc458f2f2c14"
+  integrity sha512-xlnAW7d0394EwlRgWJ+nuQNQmGkL0qBE54pN+1IBbUEFvWW8q0SbhDsTmlGgeDM+9F8q2KM06Ip1JMmddppA/Q==
 
-"@safe-global/sdk-starter-kit@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/sdk-starter-kit/-/sdk-starter-kit-1.1.0.tgz#22e5166a8f8b39614e809e4b14953f20e2510dfa"
-  integrity sha512-MFyw+ffCN+oj0fRMR/so1D8dtqozYpAummCwtZvS1d57AiPLYKe2qPP5evFdQ1w1+1V47kzZrxzmpPX3dwUAZw==
+"@safe-global/sdk-starter-kit@2.0.0-alpha.2":
+  version "2.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/sdk-starter-kit/-/sdk-starter-kit-2.0.0-alpha.2.tgz#2cbdbaac94954191ef13dc51cf5435079c80ac22"
+  integrity sha512-EJM7UYSenw2j+wRDeV2HXIOw8ZL24sJJLO16GblyNGqUFX4XOwLII1ReATcW/yTMPFH2A9I3ZzrKqwj19ucM5A==
   dependencies:
-    "@safe-global/api-kit" "^2.5.5"
-    "@safe-global/protocol-kit" "^5.1.0"
-    "@safe-global/relay-kit" "^3.3.0"
-    "@safe-global/types-kit" "^1.0.1"
+    "@safe-global/api-kit" "^3.0.0-alpha.2"
+    "@safe-global/protocol-kit" "^6.0.0-alpha.2"
+    "@safe-global/relay-kit" "^4.0.0-alpha.2"
+    "@safe-global/types-kit" "^2.0.0-alpha.2"
     viem "^2.21.8"
 
-"@safe-global/types-kit@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-1.0.0.tgz#d1f29d65a8ac22f03b0cd3ab54fb518dcf7a85c3"
-  integrity sha512-jZNUeHbWobeVrURbcEvfas4Q1IDasQni5UYm2umUtAR6SBDazp1kGni8IjZPRKq3+8q+fYwu9FmKpX50rUYn3w==
-  dependencies:
-    abitype "^1.0.2"
-
-"@safe-global/types-kit@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-1.0.1.tgz#f725e9f3f7b9ed0a052824348962fe8e16cf924d"
-  integrity sha512-T1mAgUVjtGehpwcZuROHgCx3DJHnaH0d2pSzYNcsEPvXlffu3lfCRTbrlmyEAVMEKtHaNvl7//v+GJKeLIeKhw==
+"@safe-global/types-kit@2.0.0-alpha.2", "@safe-global/types-kit@^2.0.0-alpha.2":
+  version "2.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/types-kit/-/types-kit-2.0.0-alpha.2.tgz#4b2792258bd77953ec6171b6c135fe9821febb57"
+  integrity sha512-M6I7xMmuB8ZnMTBBny3T+8Rbzsawr6guLL1khFYndfnZ+LG845Oiw+cxd+e7+rZg7DZjTtJ+P5YdFIj1iPpBuQ==
   dependencies:
     abitype "^1.0.2"
 


### PR DESCRIPTION
We are updating the SDK packages as we are launching a major version

fix: `getSafePendingOperations` now is working properly and returning the pending operations instead all