### PR TITLE
fix: add least-privilege permissions and pin actions to SHAs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+          ref: c4fd58f9c721aca09b841c8035ce1d115ed5f3c3 # v2.4.18
       - name: 'CLA Assistant'
         uses: ./reusable-workflows/actions/cla
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,41 +5,26 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-permissions:
-  actions: write
-  contents: read
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
-  CLAAssistant:
+  CLAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
-      - name: 'CLA Assistant'
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+      - name: Checkout reusable workflows
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          # user names of users allowed to contribute without CLA
+          repository: safe-global/github-reusable-workflows
+          token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
+          path: reusable-workflows
+          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+      - name: 'CLA Assistant'
+        uses: ./reusable-workflows/actions/cla
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
           allowlist: dasanra,DaniSomoza,yagopv,tmjssz,bot*
-
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-organization-name: 'safe-global'
-          # enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: 'cla-signatures'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,12 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
@@ -12,7 +18,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,16 @@
 name: 'ESLint check'
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: yarn

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - development
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,9 +16,9 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -29,7 +33,7 @@ jobs:
         run: yarn coverage
 
       - name: Upload coverage report
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage/lcov.info


### PR DESCRIPTION
Resolves three `actions/missing-workflow-permissions` warnings and the org SHA-pin policy.

Permissions:
- `cla.yml`: CLA bot needs `pull-requests`/`statuses: write` to comment and set status; `actions: write` so it can re-trigger itself.
- `lint.yml`, `unit-test.yml`: `contents: read` for checkout. `coverallsapp/github-action` uses its own Coveralls token.

Pinned `contributor-assistant/github-action@v2.2.0`, `actions/checkout@v4`, `actions/setup-node@v4`, and `coverallsapp/github-action@v2` to their tag SHAs.
